### PR TITLE
New option retain_ligand_protonation that skips babel and retains ligand protonation state

### DIFF
--- a/BAT/BAT.py
+++ b/BAT/BAT.py
@@ -48,6 +48,7 @@ rec_dihcf_force = 0
 buffer_z = 0
 num_waters = 0
 ion_conc = 0.0
+retain_ligand_protonation = 'no'
 
 # Read arguments that define input file and stage
 if len(sys.argv) < 5:
@@ -127,6 +128,8 @@ for i in range(0, len(lines)):
                 poses_list.append(scripts.check_input('int', newline[j], input_file, lines[i][0]))
         elif lines[i][0] == 'calc_type':
             calc_type = lines[i][1].lower()
+        elif lines[i][0] == 'retain_ligand_protonation':
+            retain_ligand_protonation = lines[i][1].lower()
         elif lines[i][0] == 'celpp_receptor':
             celp_st = lines[i][1]
         elif lines[i][0] == 'p1':
@@ -405,7 +408,7 @@ if stage == 'equil':
     # Get number of simulations
     num_sim = len(release_eq)
     # Create aligned initial complex
-    anch = build.build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ligand_ff, ligand_ph)
+    anch = build.build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ligand_ff, ligand_ph, retain_ligand_protonation)
     if anch == 'anch1':
       aa1_poses.append(pose)
       os.chdir('../')

--- a/BAT/lib/build.py
+++ b/BAT/lib/build.py
@@ -9,7 +9,7 @@ import subprocess as sp
 import sys as sys
 from lib import scripts as scripts
 
-def build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ligand_ff, ligand_ph):
+def build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ligand_ff, ligand_ph, retain_ligand_protonation):
 
     # Not apply SDR distance when equilibrating
     sdr_dist = 0
@@ -97,7 +97,37 @@ def build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_
 
     # Get parameters and adjust files
     if calc_type == 'dock':
-      sp.call('babel -i pdb '+pose+'.pdb -o pdb '+mol.lower()+'.pdb -d', shell=True)
+
+      # Mudong's mod: optionally retain the ligand protonation state as provided in pose*.pdb, and skip Babel processing (removing H, adding H, determining total charge)
+      if retain_ligand_protonation == 'yes':
+        print('Ligand protonation is retained, because retain_ligand_protonation option is turned on')
+      # Determine ligand net charge by reading the rightmost column of pose*.pdb, programs such as Maestro writes atom charges there
+        ligand_charge = 0
+        with open(''+pose+'.pdb') as f_in:
+          for line in f_in:
+            if '1+' in line:
+              ligand_charge += 1
+            elif '2+' in line:
+              ligand_charge += 2
+            elif '1-' in line:
+              ligand_charge += -1
+            elif '2-' in line:
+              ligand_charge += -2
+        print('The net charge of the ligand is %d' %ligand_charge)
+        if not os.path.exists('../ff/%s.mol2' %mol.lower()):
+          print('Antechamber parameters command: antechamber -i '+pose+'.pdb -fi pdb -o '+mol.lower()+'.mol2 -fo mol2 -c bcc -s 2 -at '+ligand_ff.lower()+' -nc %d' % ligand_charge)
+          sp.call('antechamber -i '+pose+'.pdb -fi pdb -o '+mol.lower()+'.mol2 -fo mol2 -c bcc -s 2 -at '+ligand_ff.lower()+' -nc %d' % ligand_charge, shell=True)
+          shutil.copy('./%s.mol2' %(mol.lower()), '../ff/')
+        if not os.path.exists('../ff/%s.frcmod' %mol.lower()):
+          if ligand_ff == 'gaff':
+            sp.call('parmchk2 -i '+mol.lower()+'.mol2 -f mol2 -o '+mol.lower()+'.frcmod -s 1', shell=True)
+          elif ligand_ff == 'gaff2':
+            sp.call('parmchk2 -i '+mol.lower()+'.mol2 -f mol2 -o '+mol.lower()+'.frcmod -s 2', shell=True)
+          shutil.copy('./%s.frcmod' %(mol.lower()), '../ff/')
+        sp.call('antechamber -i '+pose+'.pdb -fi pdb -o '+mol.lower()+'.pdb -fo pdb', shell=True)
+
+      else:
+        sp.call('babel -i pdb '+pose+'.pdb -o pdb '+mol.lower()+'.pdb -d', shell=True)
     sp.call('babel -i pdb '+mol.lower()+'.pdb -o pdb '+mol.lower()+'-h.pdb -p %4.2f' %ligand_ph, shell=True)
     sp.call('babel -i pdb '+mol.lower()+'.pdb -o mol2 '+mol.lower()+'-crg.mol2 -p %4.2f' %ligand_ph, shell=True)
     # Get ligand net charge from babel

--- a/BAT/lib/build.py
+++ b/BAT/lib/build.py
@@ -109,10 +109,18 @@ def build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_
               ligand_charge += 1
             elif '2+' in line:
               ligand_charge += 2
+            elif '3+' in line:
+              ligand_charge += 3
+            elif '4+' in line:
+              ligand_charge += 4
             elif '1-' in line:
               ligand_charge += -1
             elif '2-' in line:
               ligand_charge += -2
+            elif '3-' in line:
+              ligand_charge += -3
+            elif '4-' in line:
+              ligand_charge += -4
         print('The net charge of the ligand is %d' %ligand_charge)
         if not os.path.exists('../ff/%s.mol2' %mol.lower()):
           print('Antechamber parameters command: antechamber -i '+pose+'.pdb -fi pdb -o '+mol.lower()+'.mol2 -fo mol2 -c bcc -s 2 -at '+ligand_ff.lower()+' -nc %d' % ligand_charge)
@@ -128,29 +136,29 @@ def build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_
 
       else:
         sp.call('babel -i pdb '+pose+'.pdb -o pdb '+mol.lower()+'.pdb -d', shell=True)
-    sp.call('babel -i pdb '+mol.lower()+'.pdb -o pdb '+mol.lower()+'-h.pdb -p %4.2f' %ligand_ph, shell=True)
-    sp.call('babel -i pdb '+mol.lower()+'.pdb -o mol2 '+mol.lower()+'-crg.mol2 -p %4.2f' %ligand_ph, shell=True)
-    # Get ligand net charge from babel
-    lig_crg = 0
-    with open('%s-crg.mol2' %mol.lower()) as f_in:
-      for line in f_in:
-        splitdata = line.split()
-        if len(splitdata) > 8:
-          lig_crg = lig_crg + float(splitdata[8].strip())
-    ligand_charge = round(lig_crg)
-    print('The protonation of the ligand is for pH %4.2f' %ligand_ph)
-    print('The net charge of the ligand is %d' %ligand_charge)
-    if not os.path.exists('../ff/%s.mol2' %mol.lower()):
-      print('Antechamber parameters command: antechamber -i '+mol.lower()+'-h.pdb -fi pdb -o '+mol.lower()+'.mol2 -fo mol2 -c bcc -s 2 -at '+ligand_ff.lower()+' -nc %d' % ligand_charge)
-      sp.call('antechamber -i '+mol.lower()+'-h.pdb -fi pdb -o '+mol.lower()+'.mol2 -fo mol2 -c bcc -s 2 -at '+ligand_ff.lower()+' -nc %d' % ligand_charge, shell=True)
-      shutil.copy('./%s.mol2' %(mol.lower()), '../ff/')
-    if not os.path.exists('../ff/%s.frcmod' %mol.lower()):
-      if ligand_ff == 'gaff':
-        sp.call('parmchk2 -i '+mol.lower()+'.mol2 -f mol2 -o '+mol.lower()+'.frcmod -s 1', shell=True)
-      elif ligand_ff == 'gaff2':
-        sp.call('parmchk2 -i '+mol.lower()+'.mol2 -f mol2 -o '+mol.lower()+'.frcmod -s 2', shell=True)
-      shutil.copy('./%s.frcmod' %(mol.lower()), '../ff/')
-    sp.call('antechamber -i '+mol.lower()+'-h.pdb -fi pdb -o '+mol.lower()+'.pdb -fo pdb', shell=True)
+        sp.call('babel -i pdb '+mol.lower()+'.pdb -o pdb '+mol.lower()+'-h.pdb -p %4.2f' %ligand_ph, shell=True)
+        sp.call('babel -i pdb '+mol.lower()+'.pdb -o mol2 '+mol.lower()+'-crg.mol2 -p %4.2f' %ligand_ph, shell=True)
+        # Get ligand net charge from babel
+        lig_crg = 0
+        with open('%s-crg.mol2' %mol.lower()) as f_in:
+          for line in f_in:
+            splitdata = line.split()
+            if len(splitdata) > 8:
+              lig_crg = lig_crg + float(splitdata[8].strip())
+        ligand_charge = round(lig_crg)
+        print('The protonation of the ligand is for pH %4.2f' %ligand_ph)
+        print('The net charge of the ligand is %d' %ligand_charge)
+        if not os.path.exists('../ff/%s.mol2' %mol.lower()):
+          print('Antechamber parameters command: antechamber -i '+mol.lower()+'-h.pdb -fi pdb -o '+mol.lower()+'.mol2 -fo mol2 -c bcc -s 2 -at '+ligand_ff.lower()+' -nc %d' % ligand_charge)
+          sp.call('antechamber -i '+mol.lower()+'-h.pdb -fi pdb -o '+mol.lower()+'.mol2 -fo mol2 -c bcc -s 2 -at '+ligand_ff.lower()+' -nc %d' % ligand_charge, shell=True)
+          shutil.copy('./%s.mol2' %(mol.lower()), '../ff/')
+        if not os.path.exists('../ff/%s.frcmod' %mol.lower()):
+          if ligand_ff == 'gaff':
+            sp.call('parmchk2 -i '+mol.lower()+'.mol2 -f mol2 -o '+mol.lower()+'.frcmod -s 1', shell=True)
+          elif ligand_ff == 'gaff2':
+            sp.call('parmchk2 -i '+mol.lower()+'.mol2 -f mol2 -o '+mol.lower()+'.frcmod -s 2', shell=True)
+          shutil.copy('./%s.frcmod' %(mol.lower()), '../ff/')
+        sp.call('antechamber -i '+mol.lower()+'-h.pdb -fi pdb -o '+mol.lower()+'.pdb -fo pdb', shell=True)
 
     # Create raw complex and clean it
     filenames = ['protein.pdb', '%s.pdb' %mol.lower()]


### PR DESCRIPTION
Hi Germano,
as talked about in our earlier email communications, I found that sometimes it is beneficial to retain the ligand protonation state specified in pose*.pdb files, and to skip some `babel` steps which remove hydrogen, add hydrogen, and determine ligand total charge. In my last commit I implemented this and added a option `retain_ligand_protonation` with default of not activating. I'd like to merge my changes to main branch of `BAT.py` to make them permanent and stay with future updates.
In my tests, when `retain_ligand_protonation` is not present in `input-sdr.in`, `BAT.py` behaves exactly the same as before this commit and prepared the system successfully; when `retain_ligand_protonation = yes` is present, `BAT.py` successfully retained protonation states and prepared the system successfully.