### PR TITLE
implementation of option align_method

### DIFF
--- a/BAT/BAT.py
+++ b/BAT/BAT.py
@@ -49,6 +49,7 @@ buffer_z = 0
 num_waters = 0
 ion_conc = 0.0
 retain_ligand_protonation = 'no'
+align_method = 'mustang'
 
 # Read arguments that define input file and stage
 if len(sys.argv) < 5:
@@ -130,6 +131,8 @@ for i in range(0, len(lines)):
             calc_type = lines[i][1].lower()
         elif lines[i][0] == 'retain_ligand_protonation':
             retain_ligand_protonation = lines[i][1].lower()
+        elif lines[i][0] == 'align_method':
+            align_method = lines[i][1].lower()
         elif lines[i][0] == 'celpp_receptor':
             celp_st = lines[i][1]
         elif lines[i][0] == 'p1':
@@ -408,7 +411,7 @@ if stage == 'equil':
     # Get number of simulations
     num_sim = len(release_eq)
     # Create aligned initial complex
-    anch = build.build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ligand_ff, ligand_ph, retain_ligand_protonation)
+    anch = build.build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ligand_ff, ligand_ph, retain_ligand_protonation, align_method)
     if anch == 'anch1':
       aa1_poses.append(pose)
       os.chdir('../')
@@ -469,7 +472,7 @@ elif stage == 'fe':
           win = k
           if int(win) == 0:
             print('window: %s%02d weight: %s' %(comp, int(win), str(weight)))
-            anch = build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def)
+            anch = build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def, align_method)
             if anch == 'anch1':
               aa1_poses.append(pose)
               break
@@ -482,7 +485,7 @@ elif stage == 'fe':
             setup.sim_files(hmr, temperature, mol, num_sim, pose, comp, win, stage, c_steps1, c_steps2, rng)
           else:
             print('window: %s%02d weight: %s' %(comp, int(win), str(weight)))
-            build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def)
+            build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def, align_method)
             setup.restraints(pose, rest, bb_start, bb_end, weight, stage, mol, comp, bb_equil, sdr_dist, dec_method)
             setup.sim_files(hmr, temperature, mol, num_sim, pose, comp, win, stage, c_steps1, c_steps2, rng)
         if anch != 'all':  
@@ -498,7 +501,7 @@ elif stage == 'fe':
           win = k
           if int(win) == 0:
             print('window: %s%02d weight: %s' %(comp, int(win), str(weight)))
-            anch = build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def)
+            anch = build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def, align_method)
             if anch == 'anch1':
               aa1_poses.append(pose)
               break
@@ -511,7 +514,7 @@ elif stage == 'fe':
             setup.sim_files(hmr, temperature, mol, num_sim, pose, comp, win, stage, r_steps1, r_steps2, rng)
           else:
             print('window: %s%02d weight: %s' %(comp, int(win), str(weight)))
-            build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def)
+            build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def, align_method)
             setup.restraints(pose, rest, bb_start, bb_end, weight, stage, mol, comp, bb_equil, sdr_dist, dec_method)
             setup.sim_files(hmr, temperature, mol, num_sim, pose, comp, win, stage, r_steps1, r_steps2, rng)
         if anch != 'all':  
@@ -529,7 +532,7 @@ elif stage == 'fe':
           win = k
           print('window: %s%02d lambda: %s' %(comp, int(win), str(weight)))
           if int(win) == 0:
-            anch = build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def)
+            anch = build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def, align_method)
             if anch == 'anch1':
               aa1_poses.append(pose)
               break
@@ -540,7 +543,7 @@ elif stage == 'fe':
             setup.restraints(pose, rest, bb_start, bb_end, weight, stage, mol, comp, bb_equil, sdr_dist, dec_method)
             setup.dec_files(temperature, mol, num_sim, pose, comp, win, stage, steps1, steps2, weight, lambdas, dec_method, ntwx)
           else:
-            build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def)
+            build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def, align_method)
             setup.dec_files(temperature, mol, num_sim, pose, comp, win, stage, steps1, steps2, weight, lambdas, dec_method, ntwx)
         if anch != 'all':  
           break
@@ -557,7 +560,7 @@ elif stage == 'fe':
           win = k
           if int(win) == 0:
             print('window: %s%02d lambda: %s' %(comp, int(win), str(weight)))
-            anch = build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def)
+            anch = build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def, align_method)
             if anch == 'anch1':
               aa1_poses.append(pose)
               break
@@ -570,7 +573,7 @@ elif stage == 'fe':
             setup.dec_files(temperature, mol, num_sim, pose, comp, win, stage, steps1, steps2, weight, lambdas, dec_method, ntwx)
           else:
             print('window: %s%02d lambda: %s' %(comp, int(win), str(weight)))
-            build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def)
+            build.build_dec(fwin, hmr, mol, pose, comp, win, water_model, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, sdr_dist, dec_method, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, ion_def, align_method)
             setup.dec_files(temperature, mol, num_sim, pose, comp, win, stage, steps1, steps2, weight, lambdas, dec_method, ntwx)
         if anch != 'all':  
           break
@@ -584,7 +587,7 @@ elif stage == 'fe':
           weight = attach_rest[k]
           win = k
           print('window: %s%02d weight: %s' %(comp, int(win), str(weight)))
-          anch = build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def)
+          anch = build.build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln, barostat, receptor_ff, ligand_ff, dt, fwin, l1_x, l1_y, l1_z, l1_range, min_adis, max_adis, sdr_dist, ion_def, align_method)
           if anch == 'anch1':
             aa1_poses.append(pose)
             break

--- a/BAT/build_files/align.tcl
+++ b/BAT/build_files/align.tcl
@@ -1,0 +1,9 @@
+mol load pdb reference.pdb
+mol load pdb complex.pdb
+set sel1 [atomselect 0 "backbone"]
+set sel2 [atomselect 1 "backbone"]
+set all [atomselect 1 all]
+$all move [measure fit $sel2 $sel1]
+set all [atomselect 1 all]
+$all writepdb aligned.pdb
+exit

--- a/BAT/lib/build.py
+++ b/BAT/lib/build.py
@@ -195,7 +195,6 @@ def build_equil(pose, celp_st, mol, H1, H2, H3, calc_type, l1_x, l1_y, l1_z, l1_
         sys.exit(1)
       
       # Call pdb4amber twice, because pdb4amber can only correct residue names of histidines before removing H (-y option).
-      # Maybe we should call pdb4amber twice like this, when align_method == 'mustang' too.
       sp.call('pdb4amber -i complex.pdb -o temp.pdb', shell=True)
       sp.call('pdb4amber -i temp.pdb -o aligned_amber.pdb -y', shell=True)
 
@@ -370,20 +369,11 @@ def build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln,
       sp.call('cpptraj -p full.prmtop -y md%02d.rst7 -x fe-ini.pdb' %fwin, shell=True)
 
       # Clean output file
-      if align_method == 'mustang':
-        with open('fe-ini.pdb') as oldfile, open('complex.pdb', 'w') as newfile:
-            for line in oldfile:
-                if not 'TER' in line and not 'WAT' in line and not str(ion_def[0]) in line and not str(ion_def[1]) in line::
-                  newfile.write(line)
-      
-      elif align_method == 'vmd':
-        with open('fe-ini.pdb') as oldfile, open('complex.pdb', 'w') as newfile:
-            for line in oldfile:
-                if not 'TER' in line and not 'WAT' in line and not str(ion_def[0]) in line and not str(ion_def[1]) in line::
-                # TER lines must be retained here, so that a multi-chain receptor has its chains being separated by TER.
-                # Here I have to rely on TER to differentiate chains because cpptraj doesn't write out chain information to fe-ini.pdb
-                #if not 'WAT' in line: 
-                  newfile.write(line)
+      with open('fe-ini.pdb') as oldfile, open('complex.pdb', 'w') as newfile:
+          for line in oldfile:
+              if not 'TER' in line and not 'WAT' in line and not str(ion_def[0]) in line and not str(ion_def[1]) in line:
+                newfile.write(line)
+    
 
       # Read protein anchors and size from equilibrium
       with open('../../../equil/'+pose+'/equil-%s.pdb' % mol.lower(), 'r') as f:
@@ -426,18 +416,6 @@ def build_rest(hmr, mol, pose, comp, win, ntpr, ntwr, ntwe, ntwx, cut, gamma_ln,
         print('Because equil simulations moved the structure, alignment is needed at the start of the step -s fe')
 
         sp.call('vmd -dispdev text -e align.tcl', shell=True)
-
-        # Put back TER lines removed by vmd alignment
-        # with open('aligned.pdb', 'r') as oldfile, open('aligned-clean.pdb', 'w') as newfile:
-        #     for line in oldfile:
-        #         splitdata = line.split()
-        #         if len(splitdata) > 4:
-        #           if line[21] != 'A':
-        #             newfile.write(line)
-
-        #     if resname_list[i] == 'NME' and atom_namelist[i] == 'CH3':
-        #       build_file.write('TER\n')
-
         sp.call('pdb4amber -i aligned.pdb -o aligned_amber.pdb -y', shell=True)
 
       else:


### PR DESCRIPTION
Hi @GHeinzelmann,
This pull request contains my latest implementation of option `align_method` which defaults to mustang, thus BAT.py should behave the same as before unless `align_method = vmd` is written in the input file.
I tested my commits with `align_method = vmd` on my CDK2 system of multiple protein chains, and was able to successfully finish ABFE calculations. To my surprise, BAT.py already works for this multi chain protein, without me committing any changes about differentiating different protein chains in pdb files: although pdb4amber prints warning when there is no `TER` line between the two protein chains in the pdb file, tleap seems to be smart enough to know (perhaps from 3d coordinates) that there are two chains, and not draw a chemical bond between the two chains.

One small change about pdb4amber below, solves histidine residue naming problem that could arise from some programs (such as Maestro) exporting pdb files with residue names incompatible with Amber conventions. Currently I put this change under `align_method == 'vmd'`, but you may consider incorporating this change about pdb4amber, even when using mustang for alignment.
```
      # Call pdb4amber twice, because pdb4amber can only correct residue names of histidines before removing H (-y option).
      # Maybe we should call pdb4amber twice like this, when align_method == 'mustang' too.
      sp.call('pdb4amber -i complex.pdb -o temp.pdb', shell=True)
      sp.call('pdb4amber -i temp.pdb -o aligned_amber.pdb -y', shell=True)
```